### PR TITLE
fix: state verification

### DIFF
--- a/pkg/oauth/authorize.go
+++ b/pkg/oauth/authorize.go
@@ -13,7 +13,7 @@ type AuthorizeRequest struct {
 	ResponseType        string `json:"response_type" validate:"required,eq=code"`
 	ClientID            string `json:"client_id" validate:"required"`
 	RedirectURI         string `json:"redirect_uri" validate:"required,url"`
-	State               string `json:"state" validate:"required"`
+	State               string `json:"state,omitempty"`
 	CodeChallenge       string `json:"code_challenge" validate:"required"`
 	CodeChallengeMethod string `json:"code_challenge_method" validate:"required,eq=S256"`
 	Scope               string `json:"scope,omitempty"`

--- a/pkg/oauth/callback.go
+++ b/pkg/oauth/callback.go
@@ -13,7 +13,7 @@ import (
 // CallbackRequest represents OAuth2.1 callback parameters from IdP
 type CallbackRequest struct {
 	Code             string `json:"code,omitempty" validate:"required_if=Error ''"`
-	State            string `json:"state" validate:"required"`
+	State            string `json:"state,omitempty"`
 	Error            string `json:"error,omitempty"`
 	ErrorDescription string `json:"error_description,omitempty"`
 }
@@ -93,8 +93,13 @@ func (s *Server) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := url.Values{}
-	params.Set("code", internalAuthCode)   // Use internal JWT authorization code
-	params.Set("state", sessionData.State) // Original state from MCP client
+	params.Set("code", internalAuthCode) // Use internal JWT authorization code
+
+	// Include state if it was provided by the client (non-empty)
+	if sessionData.State != "" {
+		params.Set("state", sessionData.State) // Original state from MCP client
+	}
+
 	clientRedirectURL.RawQuery = params.Encode()
 
 	// Redirect back to MCP client

--- a/pkg/oauth/session.go
+++ b/pkg/oauth/session.go
@@ -88,7 +88,7 @@ func (jsm *JWTSessionManager) Get(stateToken string) (*SessionData, bool) {
 	redirectURI, _ := claims["redirect_uri"].(string)
 	clientID, _ := claims["client_id"].(string)
 
-	if state == "" || codeChallenge == "" || redirectURI == "" {
+	if codeChallenge == "" || redirectURI == "" {
 		jsm.logger.Error("Missing required claims in JWT")
 		return nil, false
 	}
@@ -160,7 +160,7 @@ func (jsm *JWTSessionManager) ValidateAuthCode(authCode string) (*SessionData, e
 	clientID, _ := claims["client_id"].(string)
 	idpCode, _ := claims["idp_code"].(string)
 
-	if state == "" || codeChallenge == "" || redirectURI == "" || idpCode == "" {
+	if codeChallenge == "" || redirectURI == "" || idpCode == "" {
 		jsm.logger.Error("Missing required claims in authorization code JWT")
 		return nil, fmt.Errorf("missing required claims in authorization code")
 	}


### PR DESCRIPTION
OAuthのフローでstateの検証はオプションにします。
実際CursorなどではStateが飛んでこないケースがありました。

https://modelcontextprotocol.io/specification/draft/basic/authorization#open-redirection

MCPの仕様としてもSHOULDで定義されているので必須はやめます